### PR TITLE
Fix typos in BinaryBlob class.

### DIFF
--- a/docs/mlproject.data.md
+++ b/docs/mlproject.data.md
@@ -19,7 +19,7 @@ The example below demonstrate how to write data into a BinaryBlob and read it ba
 from mlproject.data import BinaryBlob
 import numpy as np
 
-blob = BinaryBob(
+blob = BinaryBlob(
     binary_file='random_data.binary', 
     index_file='random_data.idx', 
     mode='w',
@@ -36,7 +36,7 @@ for idx, sample in enumerate(data):
 blob.close()
 
 # now we open the blob and read data back
-recon_blob = BinaryBob(
+recon_blob = BinaryBlob(
     binary_file='random_data.binary', 
     index_file='random_data.idx', 
     mode='r', # remember to open in read mode, otherwise the data files will be deleted!

--- a/mlproject/data.py
+++ b/mlproject/data.py
@@ -125,7 +125,7 @@ class BinaryBlob(TorchDataset):
         if self._mode == 'write':
             raise RuntimeError('__getitem__ is not supported when BinaryBlob is opened in write mode')
 
-        if idx >= len(self):
+        if i >= len(self):
             raise RuntimeError(f'index {i} is out of range: [0 - {len(self)})')
         idx = self._sorted_indices[i]
         return self.read_index(idx)


### PR DESCRIPTION
- Fix typos in the BinaryBlob document.
- Fix typos in the BinaryBlob __getitem__ method,