### PR TITLE
Fix contiune train

### DIFF
--- a/mlproject/trainer.py
+++ b/mlproject/trainer.py
@@ -588,7 +588,11 @@ class Trainer:
 
         start_stamp = time.time()
 
+        epoch_ended = False
         for inputs, labels in data['dataloader']:
+            if epoch_ended:
+                break
+
             pre_gpu_stamp = time.time()
 
             if self.move_data_to_device:


### PR DESCRIPTION
When we load a checkpoint from a previous train that is in the middle of an epoch, in the `update_loop` function of `Trainer` class,  the variable `epoch_ended` will be set correctly during the new training but it does stop the current epoch when `epoch_ended` set to `True`.

I propose a fix for this problem.