### PR TITLE
Add sorting to result folders and trial folders

### DIFF
--- a/mlproject/exp_summarizer.py
+++ b/mlproject/exp_summarizer.py
@@ -108,7 +108,7 @@ def summarize_experiments(
 
     # parse results from each experiment run
     result_dirs = [os.path.join(output_dir, f) for f in os.listdir(output_dir)]
-    result_dirs = [f for f in result_dirs if os.path.isdir(f)]
+    result_dirs = sorted([f for f in result_dirs if os.path.isdir(f)])
     if len(result_dirs) == 0:
         raise RuntimeError(f'Cannot find any results under {output_dir}')
 
@@ -116,7 +116,7 @@ def summarize_experiments(
     config_values = []
     for result_folder in result_dirs:
         # result_folder holds results of all trial runs for one experiment config
-        trial_run_results = [os.path.join(result_folder, f) for f in os.listdir(result_folder)]
+        trial_run_results = sorted([os.path.join(result_folder, f) for f in os.listdir(result_folder)])
         for folder in trial_run_results:
             if not os.path.isdir(folder):
                 raise RuntimeError(


### PR DESCRIPTION
Add sorting to result folders and trial folders since `os.listdir` will return the order in arbitrary order. 
**Note**: `sorted` function will sort the path in alphabetical order, not dictionary order.

With this updating, the config index created manually in
```
table = pd.DataFrame.from_dict(table)
table.index = [f'config_index={i}' for i in range(len(results))]
table.to_csv(output_file + '_results.csv', sep=delimiter)
```


 and the config content should match. But it could be better if we extract the config index from the file or directory name.